### PR TITLE
implement `sc4pac://` protocol handler

### DIFF
--- a/.github/workflows/sc4pac-gui.yaml
+++ b/.github/workflows/sc4pac-gui.yaml
@@ -111,6 +111,7 @@ jobs:
           mkdir dist-linux-x64
           tar -xvf sc4pac-gui-linux-x64-artifact.tar --directory dist-linux-x64
           unzip -d dist-linux-x64/cli sc4pac-cli.zip
+          cp -p scripts/sc4pac-gui.desktop dist-linux-x64/
           (cd dist-linux-x64 && zip -r ../sc4pac-gui-linux-x64.zip .)
       - name: Package windows
         run: |

--- a/lib/data.dart
+++ b/lib/data.dart
@@ -195,6 +195,8 @@ class PackageInfoResult {
   final Map<String, dynamic> remote;
   PackageInfoResult(this.local, this.remote);
   factory PackageInfoResult.fromJson(Map<String, dynamic> json) => _$PackageInfoResultFromJson(json);
+
+  static final PackageInfoResult notFound = PackageInfoResult((statuses: const {}), const {});
 }
 
 @JsonSerializable()

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -50,7 +50,8 @@ class CommandlineArgs {
   String? cliDir;
   bool launchServer = true;
   Uri? uri;  // currently unused
-  static const sc4pacProtocol = "sc4pac://";
+  static const sc4pacProtocolScheme = "sc4pac";
+  static const sc4pacProtocol = "$sc4pacProtocolScheme://";
   CommandlineArgs(List<String> args) {
     if (args.isNotEmpty && args[0].startsWith(sc4pacProtocol)) {
       // URI currently needs to be the first argument, see https://github.com/llfbandit/app_links/issues/129

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,8 +23,10 @@ void main(List<String> args) async {
     final segments = io.File(io.Platform.resolvedExecutable).uri.pathSegments;
     final exeName = segments.isEmpty ? "sc4pac-gui" : segments.last;
     io.stdout.writeln(
-"""Usage: $exeName [options]
+"""Usage: $exeName [URI] [options]
 Version ${appInfo.version}
+
+URI: an optional "${CommandlineArgs.sc4pacProtocol}" URL passed as first argument
 
 Options
   --port number           Port of sc4pac server (default: ${Sc4pacClient.defaultPort})
@@ -47,7 +49,14 @@ class CommandlineArgs {
   String? profilesDir;
   String? cliDir;
   bool launchServer = true;
+  Uri? uri;  // currently unused
+  static const sc4pacProtocol = "sc4pac://";
   CommandlineArgs(List<String> args) {
+    if (args.isNotEmpty && args[0].startsWith(sc4pacProtocol)) {
+      // URI currently needs to be the first argument, see https://github.com/llfbandit/app_links/issues/129
+      uri = Uri.tryParse(args[0]);
+      args = args.sublist(1);
+    }
     while (args.isNotEmpty) {
       switch (args) {
         case ["--port", var p, ...(var rest)]:           port = int.tryParse(p); args = rest; break;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -498,7 +498,6 @@ class NavRail extends StatefulWidget {
   State<NavRail> createState() => _NavRailState();
 }
 class _NavRailState extends State<NavRail> {
-  int _selectedIndex = 0;
 
   @override
   Widget build(BuildContext context) {
@@ -511,10 +510,10 @@ class _NavRailState extends State<NavRail> {
                 constraints: BoxConstraints(minHeight: constraint.maxHeight),
                 child: IntrinsicHeight(child:
                   NavigationRail(
-                    selectedIndex: _selectedIndex,
+                    selectedIndex: widget.world.navRailIndex,
                     onDestinationSelected: (int index) {
                       setState(() {
-                        _selectedIndex = index;
+                        widget.world.navRailIndex = index;
                       });
                     },
                     labelType: NavigationRailLabelType.all,  // or selected,
@@ -547,7 +546,7 @@ class _NavRailState extends State<NavRail> {
             // const VerticalDivider(thickness: 1, width: 1),
             // This is the main content.
             Expanded(
-              child: switch (_selectedIndex) {
+              child: switch (widget.world.navRailIndex) {
                 0 => DashboardScreen(widget.world.profile.dashboard, widget.world.client),
                 1 => FindPackagesScreen(widget.world.profile.findPackages),
                 2 => MyPluginsScreen(widget.world.profile.myPlugins),

--- a/lib/model.dart
+++ b/lib/model.dart
@@ -110,9 +110,9 @@ class Sc4pacClient /*extends ChangeNotifier*/ {
   final WebSocketChannel connection;
   ClientStatus status = ClientStatus.connecting;
   final void Function() onConnectionLost;
-  final void Function(BareModule, {required String channelUrl}) openPackage;
+  final void Function(List<BareModule>, Set<String> channelUrls) openPackages;
 
-  Sc4pacClient(this.authority, {required this.onConnectionLost, required this.openPackage}) :
+  Sc4pacClient(this.authority, {required this.onConnectionLost, required this.openPackages}) :
     wsUrl = 'ws://$authority',
     connection = serverConnect('ws://$authority')  // TODO appears to unregister automatically when application exits
   {
@@ -142,11 +142,10 @@ class Sc4pacClient /*extends ChangeNotifier*/ {
       if (type == '/prompt/open/package') {
         final msg = PromptOpenPackage.fromJson(data);
         if (msg.packages.isNotEmpty) {
-          if (msg.packages.length > 1) {
-            debugPrint("Opening more than 1 packages is not implemented.");
-          }
-          final item = msg.packages.first;
-          openPackage(BareModule.parse(item.package), channelUrl: item.channelUrl);
+          openPackages(
+            msg.packages.map((item) => BareModule.parse(item.package)).toList(),
+            msg.packages.map((item) => item.channelUrl).toSet(),
+          );
         }
       } else {
         debugPrint('Message type not implemented: $data');

--- a/lib/model.dart
+++ b/lib/model.dart
@@ -186,6 +186,8 @@ class Sc4pacClient /*extends ChangeNotifier*/ {
     final response = await http.get(Uri.http(authority, '/packages.info', {'pkg': module.toString(), 'profile': profileId}));
     if (response.statusCode == 200) {
       return PackageInfoResult.fromJson(jsonUtf8Decode(response.bodyBytes) as Map<String, dynamic>);
+    } else if (response.statusCode == 404) {
+      return PackageInfoResult.notFound;
     } else {
       throw ApiError(jsonUtf8Decode(response.bodyBytes) as Map<String, dynamic>);
     }

--- a/lib/model.dart
+++ b/lib/model.dart
@@ -16,6 +16,7 @@ class BareModule extends Equatable {
   final String group, name;
   const BareModule(this.group, this.name);
   @override toString() => '$group:$name';
+  String toJson() => toString();
   @override List<Object> get props => [group, name];
 
   factory BareModule.parse(String s) {
@@ -197,6 +198,20 @@ class Sc4pacClient /*extends ChangeNotifier*/ {
       if (category?.isNotEmpty == true) 'category': category,
       if (channel?.isNotEmpty == true) 'channel': channel,
     }));
+    if (response.statusCode == 200) {
+      return (jsonUtf8Decode(response.bodyBytes) as List<dynamic>)
+          .map((item) => PackageSearchResultItem.fromJson(item as Map<String, dynamic>))
+          .toList();
+    } else {
+      throw ApiError(jsonUtf8Decode(response.bodyBytes) as Map<String, dynamic>);
+    }
+  }
+
+  Future<List<PackageSearchResultItem>> searchById(List<BareModule> packages, {required String profileId}) async {
+    final response = await http.post(Uri.http(authority, '/packages.search.id', {'profile': profileId}),
+      body: jsonUtf8Encode({'packages': packages}),
+      headers: {'Content-Type': 'application/json'},
+    );
     if (response.statusCode == 200) {
       return (jsonUtf8Decode(response.bodyBytes) as List<dynamic>)
           .map((item) => PackageSearchResultItem.fromJson(item as Map<String, dynamic>))

--- a/lib/protocol_handler.dart
+++ b/lib/protocol_handler.dart
@@ -1,0 +1,27 @@
+import 'dart:io' show Platform;
+import 'package:win32_registry/win32_registry.dart';
+
+// from https://github.com/llfbandit/app_links/blob/master/doc/README_windows.md
+Future<void> registerProtocolScheme(String scheme) async {
+  if (!Platform.isWindows) {
+    return;
+  }
+  String appPath = Platform.resolvedExecutable;
+
+  String protocolRegKey = 'Software\\Classes\\$scheme';
+  RegistryValue protocolRegValue = const RegistryValue(
+    'URL Protocol',
+    RegistryValueType.string,
+    '',
+  );
+  String protocolCmdRegKey = 'shell\\open\\command';
+  RegistryValue protocolCmdRegValue = RegistryValue(
+    '',
+    RegistryValueType.string,
+    '"$appPath" "%1"',  // TODO add optional arguments here if any?
+  );
+
+  final regKey = Registry.currentUser.createKey(protocolRegKey);
+  regKey.createValue(protocolRegValue);
+  regKey.createKey(protocolCmdRegKey).createValue(protocolCmdRegValue);
+}

--- a/lib/protocol_handler_none.dart
+++ b/lib/protocol_handler_none.dart
@@ -1,0 +1,3 @@
+// dummy implementation for other platforms
+Future<void> registerProtocolScheme(String scheme) async {
+}

--- a/lib/viewmodel.dart
+++ b/lib/viewmodel.dart
@@ -37,6 +37,7 @@ class World extends ChangeNotifier {
   late Profile profile;
   late Future<({bool initialized, Map<String, dynamic> data})> readProfileFuture;
   late SettingsData settings;
+  int navRailIndex = 0;
   // themeMode
   // other gui settings
 
@@ -180,13 +181,15 @@ class World extends ChangeNotifier {
         ));
       } else {
         assert(packages.isNotEmpty);
-        if (packages.length > 1) {
-          debugPrint("Opening more than 1 package is not implemented.");
-        }
-        final module = packages.first;  // TODO open multiple
-        final context = NavigationService.navigatorKey.currentContext;
-        if (context != null && context.mounted) {
-          PackagePage.pushPkg(context, module, refreshPreviousPage: () {});  // refresh not possible since current page can be anything
+        if (packages case [final module]) {  // single package is opened directly
+          final context = NavigationService.navigatorKey.currentContext;
+          if (context != null && context.mounted) {
+            PackagePage.pushPkg(context, module, refreshPreviousPage: () {});  // refresh not possible since current page can be anything
+          }
+        } else {  // multiple packages are opened in FindPackages screen
+          profile.findPackages.customFilter = (packages: packages, unknownChannelUrls: unknownChannelUrls);
+          navRailIndex = 1;  // switch to FindPackages
+          notifyListeners();
         }
       }
     }
@@ -208,6 +211,7 @@ class FindPackages {
   String? searchTerm;
   String? selectedCategory;
   String? selectedChannelUrl;
+  ({List<BareModule> packages, Set<String> unknownChannelUrls})? customFilter;
 }
 
 enum InstallStateType { markedForInstall, explicitlyInstalled, installedAsDependency }

--- a/lib/viewmodel.dart
+++ b/lib/viewmodel.dart
@@ -189,6 +189,10 @@ class World extends ChangeNotifier {
         } else {  // multiple packages are opened in FindPackages screen
           profile.findPackages.customFilter = (packages: packages, unknownChannelUrls: unknownChannelUrls);
           navRailIndex = 1;  // switch to FindPackages
+          final context = NavigationService.navigatorKey.currentContext;
+          if (context != null && context.mounted) {
+            Navigator.popUntil(context, ModalRoute.withName('/'));  // close potential package pages
+          }
           notifyListeners();
         }
       }

--- a/lib/widgets/findpackages.dart
+++ b/lib/widgets/findpackages.dart
@@ -6,64 +6,30 @@ import '../model.dart';
 import '../viewmodel.dart';
 import 'fragments.dart';
 
-class FindPackagesScreen extends StatefulWidget {
+class FindPackagesScreen extends StatelessWidget {
   final FindPackages findPackages;
   const FindPackagesScreen(this.findPackages, {super.key});
-
-  @override
-  State<FindPackagesScreen> createState() => _FindPackagesScreenState();
-}
-class _FindPackagesScreenState extends State<FindPackagesScreen> {
-  late Future<List<PackageSearchResultItem>> searchResultFuture;
-
-  @override
-  void initState() {
-    super.initState();
-    _search();
-  }
-
-  void _search() {
-    final searchTerm = widget.findPackages.searchTerm;
-    final category = widget.findPackages.selectedCategory;
-    final channelUrl = widget.findPackages.selectedChannelUrl;
-    final customFilter = widget.findPackages.customFilter;
-    if (customFilter != null) {
-      searchResultFuture = World.world.client.searchById(customFilter.packages, profileId: World.world.profile.id);
-    } else if ((searchTerm?.isNotEmpty ?? false) || category != null) {
-      searchResultFuture = World.world.client.search(searchTerm ?? '', category: category, channel: channelUrl, profileId: World.world.profile.id);
-    } else {
-      searchResultFuture = Future.value([]);
-    }
-  }
-
-  void _refresh() {
-    setState(() {
-      _search();
-    });
-  }
 
   static const double _toolBarHeight = 100.0;
 
   @override
   Widget build(BuildContext context) {
-    return CustomScrollView(
-      slivers: [
+    return ListenableBuilder(
+      listenable: findPackages,
+      builder: (context, child) => CustomScrollView(slivers: [
         SliverAppBar(
           floating: true,
           // pinned: true,  // TODO consider pinning to avoid scroll physics auto-scrolling to top when touching app bar
           // flexibleSpace: Placeholder(), // placeholder widget to visualize the shrinking size
           // expandedHeight: 200, // initial height of the SliverAppBar larger than normal
           toolbarHeight: _toolBarHeight,
-          title: widget.findPackages.customFilter != null
+          title: findPackages.customFilter != null
             ? InputChip(
               label: const Text("Custom package filter"),
               backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
               labelStyle: TextStyle(color: Theme.of(context).colorScheme.onSecondaryContainer),
               onDeleted: () {
-                setState(() {
-                  widget.findPackages.customFilter = null;
-                  _search();
-                });
+                findPackages.updateCustomFilter(null);
               },
             )
             : Table(
@@ -81,12 +47,9 @@ class _FindPackagesScreenState extends State<FindPackagesScreen> {
                   future: World.world.profile.channelStatsFuture,
                   builder: (context, snapshot) => ChannelFilterMenu(
                     stats: snapshot.data,
-                    initialChannelUrl: widget.findPackages.selectedChannelUrl,
+                    initialChannelUrl: findPackages.selectedChannelUrl,
                     onSelectionChanged: (s) {
-                      setState(() {
-                        widget.findPackages.selectedChannelUrl = s;
-                        _search();
-                      });
+                      findPackages.updateChannelUrl(s);
                     },
                   ),
                 ),
@@ -98,45 +61,36 @@ class _FindPackagesScreenState extends State<FindPackagesScreen> {
                     return CategoryMenu(
                       stats: switch (snapshot.data) {
                         null => null,  // data not yet available
-                        final allStats => switch (allStats.channels.indexWhere((item) => item.url == widget.findPackages.selectedChannelUrl)) {
+                        final allStats => switch (allStats.channels.indexWhere((item) => item.url == findPackages.selectedChannelUrl)) {
                           -1 => allStats.combined,  // all channels selected
                           final i => allStats.channels[i].stats,
                         },
                       },
-                      initialCategory: widget.findPackages.selectedCategory,
+                      initialCategory: findPackages.selectedCategory,
                       menuHeight: max(300,
                         MediaQuery.of(context).size.height - _toolBarHeight
                         - MediaQuery.of(context).viewInsets.bottom,  // e.g. on-screen keyboard height
                       ),
                       onSelected: (s) {
-                        setState(() {
-                          widget.findPackages.selectedCategory = s;
-                          _search();
-                        });
+                        findPackages.updateCategory(s);
                       },
                     );
                   },
                 ),
                 const SizedBox(),
                 PackageSearchBar(
-                  initialText: widget.findPackages.searchTerm,
+                  initialText: findPackages.searchTerm,
                   hintText: "search term or URL…",
-                  onSubmitted: (String query) => setState(() {
-                    widget.findPackages.searchTerm = query;
-                    _search();
-                  }),
-                  onCanceled: () => setState(() {
-                    widget.findPackages.searchTerm = '';
-                    _search();
-                  }),
-                  resultsCount: searchResultFuture.then((data) => data.length),
+                  onSubmitted: (String query) => findPackages.updateSearchTerm(query),
+                  onCanceled: () => findPackages.updateSearchTerm(''),
+                  resultsCount: findPackages.searchResult.then((data) => data.length),
                 ),
               ],
             )],
           ),
         ),
         FutureBuilder<List<PackageSearchResultItem>>(
-          future: searchResultFuture,
+          future: findPackages.searchResult,
           builder: (context, snapshot) {
             if (snapshot.hasError) {
               return SliverToBoxAdapter(child: Center(child: ApiErrorWidget(ApiError.from(snapshot.error!))));
@@ -155,8 +109,8 @@ class _FindPackagesScreenState extends State<FindPackagesScreen> {
                     return PackageTile(module, index,
                       summary: item.summary,
                       status: item.status,
-                      refreshParent: _refresh,
-                      onToggled: (checked) => World.world.profile.dashboard.pendingUpdates.onToggledStarButton(module, checked, refreshParent: _refresh),
+                      refreshParent: findPackages.refreshSearchResult,
+                      onToggled: (checked) => World.world.profile.dashboard.pendingUpdates.onToggledStarButton(module, checked, refreshParent: findPackages.refreshSearchResult),
                     );
                   },
                   childCount: snapshot.data!.length,
@@ -165,7 +119,7 @@ class _FindPackagesScreenState extends State<FindPackagesScreen> {
             }
           },
         ),
-      ],
+      ]),
     );
   }
 }

--- a/lib/widgets/findpackages.dart
+++ b/lib/widgets/findpackages.dart
@@ -109,6 +109,7 @@ class FindPackagesScreen extends StatelessWidget {
                     return PackageTile(module, index,
                       summary: item.summary,
                       status: item.status,
+                      debugChannelUrls: findPackages.customFilter?.debugChannelUrls,
                       refreshParent: findPackages.refreshSearchResult,
                       onToggled: (checked) => World.world.profile.dashboard.pendingUpdates.onToggledStarButton(module, checked, refreshParent: findPackages.refreshSearchResult),
                     );

--- a/lib/widgets/findpackages.dart
+++ b/lib/widgets/findpackages.dart
@@ -26,7 +26,10 @@ class _FindPackagesScreenState extends State<FindPackagesScreen> {
     final searchTerm = widget.findPackages.searchTerm;
     final category = widget.findPackages.selectedCategory;
     final channelUrl = widget.findPackages.selectedChannelUrl;
-    if ((searchTerm?.isNotEmpty ?? false) || category != null) {
+    final customFilter = widget.findPackages.customFilter;
+    if (customFilter != null) {
+      searchResultFuture = World.world.client.searchById(customFilter.packages, profileId: World.world.profile.id);
+    } else if ((searchTerm?.isNotEmpty ?? false) || category != null) {
       searchResultFuture = World.world.client.search(searchTerm ?? '', category: category, channel: channelUrl, profileId: World.world.profile.id);
     } else {
       searchResultFuture = Future.value([]);
@@ -51,7 +54,19 @@ class _FindPackagesScreenState extends State<FindPackagesScreen> {
           // flexibleSpace: Placeholder(), // placeholder widget to visualize the shrinking size
           // expandedHeight: 200, // initial height of the SliverAppBar larger than normal
           toolbarHeight: _toolBarHeight,
-          title: Table(
+          title: widget.findPackages.customFilter != null
+            ? InputChip(
+              label: const Text("Custom package filter"),
+              backgroundColor: Theme.of(context).colorScheme.secondaryContainer,
+              labelStyle: TextStyle(color: Theme.of(context).colorScheme.onSecondaryContainer),
+              onDeleted: () {
+                setState(() {
+                  widget.findPackages.customFilter = null;
+                  _search();
+                });
+              },
+            )
+            : Table(
             columnWidths: const {
               0: IntrinsicColumnWidth(),
               1: FixedColumnWidth(10),  // padding

--- a/lib/widgets/fragments.dart
+++ b/lib/widgets/fragments.dart
@@ -374,10 +374,11 @@ class PackageTile extends StatelessWidget {
   final List<Widget> chips;
   final InstalledStatus? status;
   final PendingUpdateStatus? pendingStatus;
+  final Set<String>? debugChannelUrls;
   final void Function(bool)? onToggled;
   final void Function() refreshParent;
   final VisualDensity? visualDensity;
-  const PackageTile(this.module, this.index, {super.key, this.summary, this.chips = const [], this.status, this.pendingStatus, this.onToggled, required this.refreshParent, this.visualDensity});
+  const PackageTile(this.module, this.index, {super.key, this.summary, this.chips = const [], this.status, this.pendingStatus, this.debugChannelUrls, this.onToggled, required this.refreshParent, this.visualDensity});
   @override
   Widget build(BuildContext context) {
     final explicit = status?.explicit ?? false;
@@ -404,7 +405,7 @@ class PackageTile extends StatelessWidget {
           Text((index+1).toString()),
         ],
       ),
-      onTap: () => PackagePage.pushPkg(context, module, refreshPreviousPage: refreshParent),
+      onTap: () => PackagePage.pushPkg(context, module, debugChannelUrls: debugChannelUrls, refreshPreviousPage: refreshParent),
     );
   }
 }

--- a/lib/widgets/myplugins.dart
+++ b/lib/widgets/myplugins.dart
@@ -51,6 +51,7 @@ class _MyPluginsScreenState extends State<MyPluginsScreen> {
     });
   }
 
+  // TODO turn MyPlugins into ChangeNotifier and move _search there (similarly to how FindPackages is set up)
   void _search() {
     final q = widget.myPlugins.searchTerm;
     final c = widget.myPlugins.selectedCategory;

--- a/lib/widgets/packagepage.dart
+++ b/lib/widgets/packagepage.dart
@@ -12,6 +12,7 @@ import '../model.dart';
 import '../viewmodel.dart';
 import 'fragments.dart';
 import '../data.dart';
+import '../main.dart' show NavigationService;
 
 class PackagePage extends StatefulWidget {
   final BareModule module;
@@ -55,7 +56,49 @@ class _PackagePageState extends State<PackagePage> {
   }
 
   void _fetchInfo() {
-    futureJson = World.world.client.info(widget.module, profileId: World.world.profile.id);
+    futureJson = World.world.client.info(widget.module, profileId: World.world.profile.id)
+      .then((PackageInfoResult data) async {
+        if (data == PackageInfoResult.notFound && widget.debugChannelUrls?.isNotEmpty == true) {
+          final myChannelUrls = await World.world.client.channelsList(profileId: World.world.profile.id);
+          final unknownChannelUrls = (widget.debugChannelUrls ?? {}).difference(myChannelUrls.toSet()).toList();
+          if (unknownChannelUrls.isNotEmpty) {
+            bool? confirmed = await showDialog<bool>(
+              context: NavigationService.navigatorKey.currentContext!,
+              builder: (context) => AlertDialog(
+                icon: const Icon(Symbols.stacks),
+                title: Text(unknownChannelUrls.length > 1 ? "Add ${unknownChannelUrls.length} new channels?" : "Add a new channel?"),
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Text(
+                      "The package comes from another channel."
+                      " Do you want to add ${unknownChannelUrls.length > 1 ? "these channels" : "this channel"} to your profile?"
+                    ),
+                    const SizedBox(height: 10),
+                    ...unknownChannelUrls.map((url) => Text(url, style: TextStyle(color: Theme.of(context).colorScheme.tertiary))),
+                  ]
+                ),
+                actions: [
+                  OutlinedButton(
+                    child: const Text("Cancel"),
+                    onPressed: () => Navigator.pop(context, false),
+                  ),
+                  OutlinedButton(
+                    child: const Text("OK"),
+                    onPressed: () => Navigator.pop(context, true),
+                  ),
+                ],
+              ),
+            );
+            if (confirmed == true) {
+              await World.world.profile.dashboard.updateChannelUrls(myChannelUrls + unknownChannelUrls);
+              // 2nd attempt at fetching info, using new channels (errors will be handled in Widget build)
+              return World.world.client.info(widget.module, profileId: World.world.profile.id);
+            }
+          }
+        }
+        return data;
+      });
   }
 
   void _refresh() {
@@ -269,7 +312,7 @@ class PackageNotFoundMessage extends StatelessWidget {
           Set<String> unknownChannelUrls = snapshot.data!;
           return ApiErrorWidget(unknownChannelUrls.isNotEmpty
             ? ApiError.unexpected(
-              """The opened package "$module" comes from a channel that is not in your list of configured channels yet."""
+              """The opened package "$module" comes from another channel."""
               " To display packages from this channel, first go to your Dashboard and add the new channel URL.",  // TODO provide dialog option to do this automatically
               unknownChannelUrls.join("\n"),
             )

--- a/lib/widgets/packagepage.dart
+++ b/lib/widgets/packagepage.dart
@@ -15,15 +15,16 @@ import '../data.dart';
 
 class PackagePage extends StatefulWidget {
   final BareModule module;
-  const PackagePage(this.module, {super.key});
+  final Set<String>? debugChannelUrls;  // for messaging purposes on 404 error
+  const PackagePage(this.module, {super.key, this.debugChannelUrls});
 
   @override
   State<PackagePage> createState() => _PackagePageState();
 
-  static Future<dynamic> pushPkg(BuildContext context, BareModule module, {required void Function() refreshPreviousPage}) {
+  static Future<dynamic> pushPkg(BuildContext context, BareModule module, {required void Function() refreshPreviousPage, Set<String>? debugChannelUrls}) {
     return Navigator.push(
       context,
-      MaterialPageRoute(barrierDismissible: true, builder: (context1) => PackagePage(module)),
+      MaterialPageRoute(barrierDismissible: true, builder: (context1) => PackagePage(module, debugChannelUrls: debugChannelUrls)),
     ).then((_) => refreshPreviousPage());
   }
 
@@ -83,6 +84,8 @@ class _PackagePageState extends State<PackagePage> {
             return Center(child: ApiErrorWidget(ApiError.from(snapshot.error!)));
           } else if (!snapshot.hasData) {
             return const Center(child: CircularProgressIndicator());
+          } else if (snapshot.data == PackageInfoResult.notFound) {
+            return Center(child: PackageNotFoundMessage(widget.module, widget.debugChannelUrls));
           } else {
             final remote = snapshot.data!.remote;
             final statuses = snapshot.data!.local.statuses;
@@ -242,6 +245,41 @@ class _PackagePageState extends State<PackagePage> {
           }
         }
       ),
+    );
+  }
+}
+
+class PackageNotFoundMessage extends StatelessWidget {
+  final BareModule module;
+  final Set<String>? debugChannelUrls;
+  const PackageNotFoundMessage(this.module, this.debugChannelUrls, {super.key});
+  @override
+  Widget build(BuildContext context) {
+    return FutureBuilder<Set<String>>(
+      // If openPackages was called with debugChannelUrls, determine
+      // which of the channels are not known yet to show a meaningful error.
+      future: debugChannelUrls?.isNotEmpty == true
+        ? World.world.profile.channelStatsFuture
+          .then((stats) => debugChannelUrls!.difference(stats.channels.map((item) => item.url).toSet()))
+        : Future.value({}),
+      builder: (context, snapshot) {
+        if (!snapshot.hasData) {
+          return const SizedBox();
+        } else {
+          Set<String> unknownChannelUrls = snapshot.data!;
+          return ApiErrorWidget(unknownChannelUrls.isNotEmpty
+            ? ApiError.unexpected(
+              """The opened package "$module" comes from a channel that is not in your list of configured channels yet."""
+              " To display packages from this channel, first go to your Dashboard and add the new channel URL.",  // TODO provide dialog option to do this automatically
+              unknownChannelUrls.join("\n"),
+            )
+            : ApiError.unexpected(
+              """The package "$module" was not found in any of your channels.""",
+              "Maybe the package was renamed or removed from its channel, or it comes from a channel that is not in your list of configured channels yet.",
+            ),
+          );
+        }
+      },
     );
   }
 }

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,10 +6,14 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <gtk/gtk_plugin.h>
 #include <open_file_linux/open_file_linux_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) gtk_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "GtkPlugin");
+  gtk_plugin_register_with_registrar(gtk_registrar);
   g_autoptr(FlPluginRegistrar) open_file_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "OpenFileLinuxPlugin");
   open_file_linux_plugin_register_with_registrar(open_file_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  gtk
   open_file_linux
   url_launcher_linux
 )

--- a/linux/my_application.cc
+++ b/linux/my_application.cc
@@ -17,6 +17,13 @@ G_DEFINE_TYPE(MyApplication, my_application, GTK_TYPE_APPLICATION)
 // Implements GApplication::activate.
 static void my_application_activate(GApplication* application) {
   MyApplication* self = MY_APPLICATION(application);
+
+  GList* windows = gtk_application_get_windows(GTK_APPLICATION(application));
+  if (windows) {
+    gtk_window_present(GTK_WINDOW(windows->data));
+    return;
+  }
+
   GtkWindow* window =
       GTK_WINDOW(gtk_application_window_new(GTK_APPLICATION(application)));
 
@@ -78,7 +85,7 @@ static gboolean my_application_local_command_line(GApplication* application, gch
   g_application_activate(application);
   *exit_status = 0;
 
-  return TRUE;
+  return FALSE;
 }
 
 // Implements GApplication::startup.
@@ -119,6 +126,6 @@ static void my_application_init(MyApplication* self) {}
 MyApplication* my_application_new() {
   return MY_APPLICATION(g_object_new(my_application_get_type(),
                                      "application-id", APPLICATION_ID,
-                                     "flags", G_APPLICATION_NON_UNIQUE,
+                                     "flags", G_APPLICATION_HANDLES_COMMAND_LINE | G_APPLICATION_HANDLES_OPEN,
                                      nullptr));
 }

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,12 +5,14 @@
 import FlutterMacOS
 import Foundation
 
+import app_links
 import open_file_mac
 import package_info_plus
 import path_provider_foundation
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   OpenFilePlugin.register(with: registry.registrar(forPlugin: "OpenFilePlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -17,6 +17,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.4.1"
+  app_links:
+    dependency: "direct main"
+    description:
+      name: app_links
+      sha256: "433df2e61b10519407475d7f69e470789d23d593f28224c38ba1068597be7950"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.3"
+  app_links_linux:
+    dependency: transitive
+    description:
+      name: app_links_linux
+      sha256: f5f7173a78609f3dfd4c2ff2c95bd559ab43c80a87dc6a095921d96c05688c81
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.3"
+  app_links_platform_interface:
+    dependency: transitive
+    description:
+      name: app_links_platform_interface
+      sha256: "05f5379577c513b534a29ddea68176a4d4802c46180ee8e2e966257158772a3f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
+  app_links_web:
+    dependency: transitive
+    description:
+      name: app_links_web
+      sha256: af060ed76183f9e2b87510a9480e56a5352b6c249778d07bd2c95fc35632a555
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   args:
     dependency: transitive
     description:
@@ -344,6 +376,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  gtk:
+    dependency: transitive
+    description:
+      name: gtk
+      sha256: e8ce9ca4b1df106e4d72dad201d345ea1a036cc12c360f1a7d5a758f78ffa42c
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.0"
   http:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -981,6 +981,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.9.0"
+  win32_registry:
+    dependency: "direct main"
+    description:
+      name: win32_registry
+      sha256: "21ec76dfc731550fd3e2ce7a33a9ea90b828fdf19a5c3bcf556fa992cfa99852"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.5"
   xdg_directories:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -56,6 +56,7 @@ dependencies:
   package_info_plus: ^8.1.1
   markdown: ^7.2.2
   app_links: ^6.3.3
+  win32_registry: ^1.1.5
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -55,6 +55,7 @@ dependencies:
   cryptography: ^2.7.0
   package_info_plus: ^8.1.1
   markdown: ^7.2.2
+  app_links: ^6.3.3
 
 dev_dependencies:
   flutter_test:

--- a/scripts/sc4pac-gui.desktop
+++ b/scripts/sc4pac-gui.desktop
@@ -1,0 +1,24 @@
+[Desktop Entry]
+Name=sc4pac GUI
+Comment=Mod Manager for SimCity 4.
+#
+# First, add sc4pac-gui to PATH or adjust the path to sc4pac-gui in "Exec" as necessary.
+#
+# Install this .desktop file in ~/.local/share/applications/
+#
+# (This step is maybe not necessary.) Update the mimeinfo.cache:
+#   update-desktop-database ~/.local/share/applications/
+#
+# Register the new MIME type by running (which adds an entry to ~/.config/mimeapps.list):
+#   xdg-mime default sc4pac-gui.desktop x-scheme-handler/sc4pac
+#
+# Test with:
+#   xdg-open "sc4pac:///package?pkg=memo:submenus-dll"
+#
+Exec=sc4pac-gui %u
+StartupNotify=false
+MimeType=x-scheme-handler/sc4pac;
+# Icon=sc4pac-gui.png
+Terminal=false
+Type=Application
+Categories=Game;PackageManager;

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -6,9 +6,12 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <app_links/app_links_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
 
 void RegisterPlugins(flutter::PluginRegistry* registry) {
+  AppLinksPluginCApiRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
   UrlLauncherWindowsRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("UrlLauncherWindows"));
 }

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  app_links
   url_launcher_windows
 )
 

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -4,9 +4,50 @@
 
 #include "flutter_window.h"
 #include "utils.h"
+#include "app_links/app_links_plugin_c_api.h"
+
+bool SendAppLinkToInstance(const std::wstring& title) {
+  // Find our exact window
+  HWND hwnd = ::FindWindow(L"FLUTTER_RUNNER_WIN32_WINDOW", title.c_str());
+
+  if (hwnd) {
+    // Dispatch new link to current window
+    SendAppLink(hwnd);
+
+    // (Optional) Restore our window to front in same state
+    WINDOWPLACEMENT place = { sizeof(WINDOWPLACEMENT) };
+    GetWindowPlacement(hwnd, &place);
+
+    switch(place.showCmd) {
+      case SW_SHOWMAXIMIZED:
+          ShowWindow(hwnd, SW_SHOWMAXIMIZED);
+          break;
+      case SW_SHOWMINIMIZED:
+          ShowWindow(hwnd, SW_RESTORE);
+          break;
+      default:
+          ShowWindow(hwnd, SW_NORMAL);
+          break;
+    }
+
+    SetWindowPos(0, HWND_TOP, 0, 0, 0, 0, SWP_SHOWWINDOW | SWP_NOSIZE | SWP_NOMOVE);
+    SetForegroundWindow(hwnd);
+    // END (Optional) Restore
+
+    // Window has been found, don't create another one.
+    return true;
+  }
+
+  return false;
+}
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
+  // support for opening "sc4pac://" protocol URLs
+  if (SendAppLinkToInstance(L"sc4pac GUI")) {
+    return EXIT_SUCCESS;
+  }
+
   // Attach to console when present (e.g., 'flutter run') or create a
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {


### PR DESCRIPTION
This adds support for a custom "sc4pac://" URL scheme to start the application and open one or more packages:

    sc4pac:///package?pkg=<pkg>&channel=<url>

The `channel` parameter is optional, but should be passed to help diagnose package-not-found errors. Note that it should end with a `/`.

To open multiple packages, pass the `pkg` parameter multiple times. In case they come from different channels, multiple `channel` parameters can be passed as well. Order does not matter. The order of packages is preserved in the GUI though.

Example:
```
sc4pac:///package?pkg=memo:submenus-dll&pkg=cyclone-boom:save-warning&pkg=warrior:god-terraforming-in-mayor-mode&pkg=orange:fagus&channel=https://memo33.github.io/sc4pac/channel/
```

On Windows, this automatically (re-)registers a handler for the protocol in the registry under `Software\Classes\sc4pac` for the current user, at every start of the application. (If you usually use custom launch arguments to start the application, these might be ignored on the initial launch of the application following a `sc4pac://` link.)

On Linux, registering the protocol handler currently needs to be done manually. See the instructions in the provided `sc4pac-gui.desktop` file.

The web-app does not support the `sc4pac://` scheme. The `/packages.open` API endpoint could be used as a fallback.

See #15 for related discussions.