### PR TITLE
handle common launch issues

### DIFF
--- a/lib/data.dart
+++ b/lib/data.dart
@@ -111,7 +111,8 @@ class InstalledListItem {
 class Profiles {
   final List<({String id, String name})> profiles;
   final List<String> currentProfileId;
-  Profiles(this.profiles, this.currentProfileId);
+  final String profilesDir;
+  Profiles(this.profiles, this.currentProfileId, this.profilesDir);
   factory Profiles.fromJson(Map<String, dynamic> json) => _$ProfilesFromJson(json);
   ({String id, String name})? currentProfile() {
     final idx = profiles.indexWhere((p) => currentProfileId.contains(p.id));

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -197,14 +197,21 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
         if (snapshot.hasError) {
           return CenteredFullscreenDialog(
             title: const Text("Establish connection"),
-            child: Column(
-              children: [
+            child: Column(children: switch (widget.world.server?.launchError) {
+              ApiError error => [
+                ApiErrorWidget(error),  // this is a dead end (e.g. Java not found or too old), so requires restarting the application once resolved
+                const SizedBox(height: 20),
+                const Text("Restart the application once the above problem is resolved."),
+              ],
+              null => [
                 ExpansionTile(
                   trailing: const Icon(Icons.info_outlined),
                   leading: const Icon(Icons.wifi_tethering_error),
                   title: Text("Connection to local sc4pac server not possible at ${widget.world.authority}"),
                   children: const [Text("The sc4pac GUI is a lightweight interface to the background sc4pac process which performs all the heavy operations on your local file system. "
-                    "The local backend server is either not running or the GUI does not know its address.")],
+                    "The local backend server is either not running or the GUI does not know its address."
+                    " As a workaround, you may connect to an existing sc4pac server process using the input field below."
+                    " Alternatively, restarting the application might resolve the problem.")],
                 ),
                 const SizedBox(height: 15),
                 TextField(
@@ -233,7 +240,7 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
                   child: const Text("Connect")
                 ),
               ],
-            ),
+            }),
           );
         } else {
           // connecting (or connection established; we don't care about the result, as initPhase change triggers next screen)

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,12 +29,14 @@ Version ${appInfo.version}
 URI: an optional "${CommandlineArgs.sc4pacProtocol}" URL passed as first argument
 
 Options
-  --port number           Port of sc4pac server (default: ${Sc4pacClient.defaultPort})
-  --host IP               Hostname of sc4pac server (default: localhost)
-  --launch-server=false   Do not launch sc4pac server from GUI, but connect to external process instead (default: true)
-  --profiles-dir path     Profiles directory for sc4pac server (default: BUNDLEDIR/profiles), resolved relative to current directory
-  --sc4pac-cli-dir path   Contains sc4pac CLI scripts for launching the server (default: BUNDLEDIR/cli), resolved relative to current directory
-  -h, --help              Print help message and exit"""
+  --port number              Port of sc4pac server (default: ${Sc4pacClient.defaultPort})
+  --host IP                  Hostname of sc4pac server (default: localhost)
+  --launch-server=false      Do not launch sc4pac server from GUI, but connect to external process instead (default: true)
+  --profiles-dir path        Profiles directory for sc4pac server (default: BUNDLEDIR/profiles), resolved relative to current directory
+  --sc4pac-cli-dir path      Contains sc4pac CLI scripts for launching the server (default: BUNDLEDIR/cli), resolved relative to current directory
+  --register-protocol=false  Do not register "${CommandlineArgs.sc4pacProtocol}" protocol handler in Windows registry (default: true, Windows only).
+                             Disabling this is useful if you manually changed the registry entry.
+  -h, --help                 Print help message and exit"""
     );
     io.exit(0);
   } else {
@@ -49,6 +51,7 @@ class CommandlineArgs {
   String? profilesDir;
   String? cliDir;
   bool launchServer = true;
+  bool registerProtocol = true;
   Uri? uri;  // currently unused
   static const sc4pacProtocolScheme = "sc4pac";
   static const sc4pacProtocol = "$sc4pacProtocolScheme://";
@@ -60,18 +63,23 @@ class CommandlineArgs {
     }
     while (args.isNotEmpty) {
       switch (args) {
-        case ["--port", var p, ...(var rest)]:           port = int.tryParse(p); args = rest; break;
-        case ["--host", var h, ...(var rest)]:           host = h;               args = rest; break;
-        case ["--profiles-dir", var p, ...(var rest)]:   profilesDir = p;        args = rest; break;
-        case ["--sc4pac-cli-dir", var p, ...(var rest)]: cliDir = p;             args = rest; break;
-        case ["--launch-server=true",  ...(var rest)]:   launchServer = true;    args = rest; break;
-        case ["--launch-server=false", ...(var rest)]:   launchServer = false;   args = rest; break;
-        case ["--help" || "-h", ...(var rest)]:          help = true;            args = rest; break;
+        case ["--port", var p, ...(var rest)]:             port = int.tryParse(p);   args = rest; break;
+        case ["--host", var h, ...(var rest)]:             host = h;                 args = rest; break;
+        case ["--profiles-dir", var p, ...(var rest)]:     profilesDir = p;          args = rest; break;
+        case ["--sc4pac-cli-dir", var p, ...(var rest)]:   cliDir = p;               args = rest; break;
+        case ["--launch-server=true",  ...(var rest)]:     launchServer = true;      args = rest; break;
+        case ["--launch-server=false", ...(var rest)]:     launchServer = false;     args = rest; break;
+        case ["--register-protocol=true",  ...(var rest)]: registerProtocol = true;  args = rest; break;
+        case ["--register-protocol=false", ...(var rest)]: registerProtocol = false; args = rest; break;
+        case ["--help" || "-h", ...(var rest)]:            help = true;              args = rest; break;
         default:
           io.stderr.writeln("Unknown trailing arguments (try --help): ${args.join(" ")}");
           args = [];
           io.exit(1);
       }
+    }
+    if (uri != null) {
+      registerProtocol = false;
     }
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -204,6 +204,8 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
                 const Text("Restart the application once the above problem is resolved."),
               ],
               null => [
+                // ApiErrorWidget(ApiError.from(snapshot.error!)),
+                // const SizedBox(height: 20),
                 ExpansionTile(
                   trailing: const Icon(Icons.info_outlined),
                   leading: const Icon(Icons.wifi_tethering_error),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -32,7 +32,7 @@ Options
   --port number              Port of sc4pac server (default: ${Sc4pacClient.defaultPort})
   --host IP                  Hostname of sc4pac server (default: localhost)
   --launch-server=false      Do not launch sc4pac server from GUI, but connect to external process instead (default: true)
-  --profiles-dir path        Profiles directory for sc4pac server (default: BUNDLEDIR/profiles), resolved relative to current directory
+  --profiles-dir path        Profiles directory for sc4pac server (default: platform-dependent), resolved relatively to current directory
   --sc4pac-cli-dir path      Contains sc4pac CLI scripts for launching the server (default: BUNDLEDIR/cli), resolved relative to current directory
   --register-protocol=false  Do not register "${CommandlineArgs.sc4pacProtocol}" protocol handler in Windows registry (default: true, Windows only).
                              Disabling this is useful if you manually changed the registry entry.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -214,6 +214,11 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
                     " Alternatively, restarting the application might resolve the problem.")],
                 ),
                 const SizedBox(height: 15),
+                if (widget.world.server?.portIsOccupied == true)
+                  ...[
+                    Text("The port ${widget.world.server?.port ?? ''} is already occupied by another process."),
+                    const SizedBox(height: 20),
+                  ],
                 TextField(
                   controller: _controller,
                   decoration: InputDecoration(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -214,11 +214,6 @@ class _ConnectionScreenState extends State<ConnectionScreen> {
                     " Alternatively, restarting the application might resolve the problem.")],
                 ),
                 const SizedBox(height: 15),
-                if (widget.world.server?.portIsOccupied == true)
-                  ...[
-                    Text("The port ${widget.world.server?.port ?? ''} is already occupied by another process."),
-                    const SizedBox(height: 20),
-                  ],
                 TextField(
                   controller: _controller,
                   decoration: InputDecoration(

--- a/lib/model.dart
+++ b/lib/model.dart
@@ -48,7 +48,7 @@ enum ServerStatus { launching, listening, terminated }
 // server is launched from desktop GUI, but not from webapp
 class Sc4pacServer {
   final String cliDir;
-  final String profilesDir;
+  final String? profilesDir;
   final int port;
   ServerStatus status = ServerStatus.launching;
   late final Future<Process> _process;
@@ -75,7 +75,8 @@ class Sc4pacServer {
         [
           "server",
           "--port", port.toString(),
-          "--profiles-dir", profilesDir,
+          if (profilesDir != null)
+            ...["--profiles-dir", profilesDir!],
           "--auto-shutdown",
           "--startup-tag", readyTag,
         ],

--- a/lib/model.dart
+++ b/lib/model.dart
@@ -54,7 +54,6 @@ class Sc4pacServer {
   late final Future<Process> _process;
   late final Future<bool> ready;  // true once server listens, false if launching server did not work (This future never fails)
   ApiError? launchError;
-  bool? portIsOccupied;
 
   static const int _javaNotFound = 55;
   static const int _portOccupied = 56;
@@ -110,8 +109,11 @@ class Sc4pacServer {
             stdout.writeln(msg);
             launchError ??= ApiError.unexpected(msg, "");
           } else if (exitCode == _portOccupied) {
-            stdout.writeln("Failed to launch local sc4pac server, as port $port is already occupied. Attempting to connect to existing process on port $port instead.");
-            portIsOccupied = true;
+            final msg = """Another program is already running on port $port. Please quit the other program – likely another instance of sc4pac.""";
+            final detail = """Alternatively, launch the sc4pac GUI on a different port (using the "--port" launch option) or connect to an existing sc4pac process on port $port (using the "--launch-server=false" option)."""
+                """\n(For technical reasons, this error can also occur if you open and close the sc4pac GUI in quick succession. In this case, just wait for 20 seconds before re-opening the application again.)""";
+            stdout.writeln("$msg $detail");
+            launchError ??= ApiError.unexpected(msg, detail);
           } else {
             stdout.writeln("Sc4pac server exited with code $exitCode");
           }

--- a/lib/viewmodel.dart
+++ b/lib/viewmodel.dart
@@ -107,11 +107,13 @@ class World extends ChangeNotifier {
           }
         }
       });
-      await protocol_handler.registerProtocolScheme(CommandlineArgs.sc4pacProtocolScheme)
-        .catchError((e) => ApiErrorWidget.dialog(ApiError.unexpected(
-          """Failed to register "${CommandlineArgs.sc4pacProtocol}" URL scheme in Windows registry.""",
-          e.toString(),
-        )));
+      if (args.registerProtocol) {
+        await protocol_handler.registerProtocolScheme(CommandlineArgs.sc4pacProtocolScheme)
+          .catchError((e) => ApiErrorWidget.dialog(ApiError.unexpected(
+            """Failed to register "${CommandlineArgs.sc4pacProtocol}" URL scheme in Windows registry.""",
+            e.toString(),
+          )));
+      }
     }
 
     initPhase = InitPhase.initialized;

--- a/lib/viewmodel.dart
+++ b/lib/viewmodel.dart
@@ -46,11 +46,12 @@ class World extends ChangeNotifier {
     this.authority = authority;
     // we call `serverStatus`, even if `ready` resolved to false (launching server failed), to allow connecting to external server process instead
     initialServerStatus = (server?.ready ?? Future.value(true)).then((isReady) =>
-      isReady ? Sc4pacClient.serverStatus(authority)
+      (isReady || server?.portIsOccupied == true) ? Sc4pacClient.serverStatus(authority)
         : Future.error(server?.launchError ?? ApiError.unexpected("Failed to launch local sc4pac server.", ""))
       );
     initialServerStatus.then(
       (serverStatus) {  // connection succeeded, so proceed to next phase
+        stdout.writeln("Connection established.");
         if (serverStatus case {'sc4pacVersion': String version}) {
           serverVersion = version;
         }

--- a/lib/viewmodel.dart
+++ b/lib/viewmodel.dart
@@ -45,7 +45,10 @@ class World extends ChangeNotifier {
     initPhase = InitPhase.connecting;
     this.authority = authority;
     // we call `serverStatus`, even if `ready` resolved to false (launching server failed), to allow connecting to external server process instead
-    initialServerStatus = (server?.ready ?? Future.value(true)).then((_) => Sc4pacClient.serverStatus(authority));
+    initialServerStatus = (server?.ready ?? Future.value(true)).then((isReady) =>
+      isReady ? Sc4pacClient.serverStatus(authority)
+        : Future.error(server?.launchError ?? ApiError.unexpected("Failed to launch local sc4pac server.", ""))
+      );
     initialServerStatus.then(
       (serverStatus) {  // connection succeeded, so proceed to next phase
         if (serverStatus case {'sc4pacVersion': String version}) {

--- a/lib/viewmodel.dart
+++ b/lib/viewmodel.dart
@@ -147,7 +147,7 @@ class World extends ChangeNotifier {
       final String bundleRoot = FileSystemEntity.parentOf(Platform.resolvedExecutable);
       server = Sc4pacServer(
         cliDir: args.cliDir ?? "$bundleRoot/cli",
-        profilesDir: args.profilesDir ?? "$bundleRoot/profiles",
+        profilesDir: args.profilesDir,
         port: port,
       );
     } else {

--- a/lib/viewmodel.dart
+++ b/lib/viewmodel.dart
@@ -44,14 +44,12 @@ class World extends ChangeNotifier {
   void updateConnection(String authority, {required bool notify}) {
     initPhase = InitPhase.connecting;
     this.authority = authority;
-    // we call `serverStatus`, even if `ready` resolved to false (launching server failed), to allow connecting to external server process instead
     initialServerStatus = (server?.ready ?? Future.value(true)).then((isReady) =>
-      (isReady || server?.portIsOccupied == true) ? Sc4pacClient.serverStatus(authority)
+      isReady ? Sc4pacClient.serverStatus(authority)
         : Future.error(server?.launchError ?? ApiError.unexpected("Failed to launch local sc4pac server.", ""))
       );
     initialServerStatus.then(
       (serverStatus) {  // connection succeeded, so proceed to next phase
-        stdout.writeln("Connection established.");
         if (serverStatus case {'sc4pacVersion': String version}) {
           serverVersion = version;
         }

--- a/lib/widgets/dashboard.dart
+++ b/lib/widgets/dashboard.dart
@@ -190,29 +190,10 @@ class _DashboardScreenState extends State<DashboardScreen> {
             leading: const Icon(Symbols.folder_supervised),
             title: const Text("Plugins folder"),
             children: [
-              Row(
-                children: [
-                  Expanded(
-                    child: Padding(
-                      padding: const EdgeInsets.all(10),
-                      child: TextFormField(
-                        decoration: const InputDecoration(
-                          labelText: 'Path'
-                        ),
-                        readOnly: true,
-                        initialValue: widget.dashboard.profile.paths?.plugins,
-                      ),
-                    ),
-                  ),
-                  if (!kIsWeb)
-                    Tooltip(message: 'Open in file browser', child: IconButton(
-                      icon: const Icon(Symbols.open_in_new_down),
-                      onPressed: widget.dashboard.profile.paths == null ? null : () {
-                        OpenFile.open(widget.dashboard.profile.paths?.plugins);  // does not work in web
-                      },
-                    )),
-                ],
-              ),
+              switch (widget.dashboard.profile.paths?.plugins) {
+                null => const SizedBox(),
+                String path => PathField(path: path),
+              },
             ],
           ),
           const ExpansionTile(

--- a/lib/widgets/fragments.dart
+++ b/lib/widgets/fragments.dart
@@ -2,12 +2,14 @@
 import 'dart:math' show Random;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:url_launcher/link.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'package:material_symbols_icons/material_symbols_icons.dart';
 import 'package:badges/badges.dart' as badges;
 import 'package:markdown/markdown.dart' as md;
 import 'package:flutter_markdown/flutter_markdown.dart' as fmd;
+import 'package:open_file/open_file.dart';
 import '../model.dart';
 import '../viewmodel.dart' show PendingUpdateStatus;
 import 'packagepage.dart';
@@ -563,4 +565,38 @@ class _CategoryMenuState extends State<CategoryMenu> {
     '710-automata': Symbols.traffic_jam,
     '900-overrides': Symbols.event_repeat,
   };
+}
+
+class PathField extends StatelessWidget {
+  final String path;
+  const PathField({required this.path, super.key});
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.all(10),
+            child: TextFormField(
+              decoration: const InputDecoration(
+                labelText: 'Path'
+              ),
+              readOnly: true,
+              initialValue: path,
+            ),
+          ),
+        ),
+        if (!kIsWeb)
+          Tooltip(message: 'Open in file browser', child: IconButton(
+            icon: const Icon(Symbols.open_in_new_down),
+            onPressed: () async {
+              OpenResult result = await OpenFile.open(path);  // does not work in web
+              if (result.type != ResultType.done) {
+                debugPrint("${result.type}: ${result.message}");
+              }
+            },
+          )),
+      ],
+    );
+  }
 }

--- a/lib/widgets/settings.dart
+++ b/lib/widgets/settings.dart
@@ -22,6 +22,22 @@ class SettingsScreen extends StatelessWidget {
             CookieWidget(),
           ],
         ),
+        ExpansionTile(
+          leading: const Icon(Symbols.folder_managed),
+          title: const Text("Profiles configuration folder"),
+          expandedCrossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Padding(
+              padding: EdgeInsets.all(10),
+              child: Text("This folder contains configuration files that store application settings as well as your profiles."),
+            ),
+            FutureBuilder<Profiles>(
+              future: World.world.profilesFuture,
+              builder: (context, snapshot) =>
+                snapshot.hasData ? PathField(path: snapshot.data!.profilesDir) : const SizedBox(),
+            ),
+          ],
+        ),
         ListenableBuilder(
           listenable: World.world,
           builder: (context, child) => SwitchListTile(

--- a/scripts/launch-GUI-web-Linux.sh
+++ b/scripts/launch-GUI-web-Linux.sh
@@ -3,4 +3,4 @@ set -e
 # Find the location of this script, accounting for symlinks, see https://stackoverflow.com/a/246128
 SCRIPTDIR="$( cd -P "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPTDIR"
-./cli/sc4pac server --port 51515 --profiles-dir profiles --web-app-dir webapp --auto-shutdown=true --launch-browser=true "$@"
+./cli/sc4pac server --port 51515 --web-app-dir webapp --auto-shutdown=true --launch-browser=true "$@"

--- a/scripts/launch-GUI-web-Windows.bat
+++ b/scripts/launch-GUI-web-Windows.bat
@@ -1,4 +1,4 @@
 @ECHO OFF
 SET SCRIPTDIR=%~dp0.
 cd "%SCRIPTDIR%"
-cli\sc4pac.bat server --port 51515 --profiles-dir profiles --web-app-dir webapp --auto-shutdown=true --launch-browser=true %*
+cli\sc4pac.bat server --port 51515 --web-app-dir webapp --auto-shutdown=true --launch-browser=true %*

--- a/scripts/launch-GUI-web-macOS.command
+++ b/scripts/launch-GUI-web-macOS.command
@@ -3,4 +3,4 @@ set -e
 # Find the location of this script, accounting for symlinks, see https://stackoverflow.com/a/246128
 SCRIPTDIR="$( cd -P "$( dirname "$(readlink -f "${BASH_SOURCE[0]}")" )" >/dev/null 2>&1 && pwd )"
 cd "$SCRIPTDIR"
-./cli/sc4pac server --port 51515 --profiles-dir profiles --web-app-dir webapp --auto-shutdown=true --launch-browser=true "$@"
+./cli/sc4pac server --port 51515 --web-app-dir webapp --auto-shutdown=true --launch-browser=true "$@"


### PR DESCRIPTION
Fixes #16. In particular, detects the following issues and provides suitable help messages:

- Java not found or too old
- `sc4pac`/`sc4pac.bat` not found or `sc4pac-cli.jar` not found
- port occupied
- generic failures launching the local server
- file-access-denied errors, in particular when creating folders like `profiles`, `plugins`, `cache`, etc.
- The default location for the `profiles` folder has changed to a platform-dependent location (shown in Settings) to ensure the user has write access to the folder which stores all JSON configuration files for the application. With this change, in case multiple installations of the GUI exist (e.g. desktop and web-app), they all use the same `profiles` directory by default. This also simplifies upgrading the GUI to newer versions. Use the `--profiles-dir` launch option to use a custom directory.